### PR TITLE
Remove AU references in JSON files

### DIFF
--- a/src/test/resources/webhook/real-enriched-listing-event.json
+++ b/src/test/resources/webhook/real-enriched-listing-event.json
@@ -266,12 +266,6 @@
       "partnerName": "move-dealer-tool-au",
       "chatId": "123123123123",
       "description": "Welcome to Dealership.",
-      "openingHours": [
-        "Mo-Fr 09:00-17:00",
-        "Sa 09:00-16:00",
-        "Su closed"
-      ],
-      "additionalOperatingHours": "",
       "locations": [
         {
           "street": "100 Main Road",
@@ -285,11 +279,6 @@
           }
         }
       ],
-      "memberUnits": [{
-        "marketplaceForeignId": "12345",
-        "memberUnit": "GTAUSCA",
-        "active": true
-      }],
       "logoUrl": "https://i.ebayimg.com/00/s/ABC123=/z/DEF456/$_26.JPG",
       "contacts": [
         {

--- a/src/test/resources/webhook/real-listing-url-event.json
+++ b/src/test/resources/webhook/real-listing-url-event.json
@@ -3,10 +3,10 @@
   "payload": {
     "listingId": "1234",
     "clientId": "some-client-id",
-    "marketplaceId": "gumtree-au",
+    "marketplaceId": "kijiji-ca",
     "marketplaceListingId": "12345",
     "partnerListingId" : "987654321",
-    "partnerId": "dealer-solutions",
+    "partnerId": "sm360",
     "sellerForeignId": "abc123",
     "sellerType": "DEALER",
     "urls": [


### PR DESCRIPTION
The public [Reference-Move-Webhook-Receiver](https://github.com/eBayClassifiedsGroup/reference-move-webhook-receiver) now fails to build as references to AU specific logic such as memberUnits and AU partnerIds exist in the json files used for tests.

This results in failures as the generated classes for listings etc. are coming from the public move api which now does not include these AU specific fields.

This PR removes AU specific fields / values from the Reference Move Webhook Receiver.